### PR TITLE
7118 v3 update

### DIFF
--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -6,16 +6,22 @@ from cachecontrol import CacheControl
 from cachecontrol.caches import FileCache
 from elex.cachecontrol_heuristics import EtagOnlyCache
 
-__version__ = '2.4.3'
-_DEFAULT_CACHE_DIRECTORY = os.path.join(tempfile.gettempdir(), 'elex-cache')
+__version__ = "2.4.3"
+_DEFAULT_CACHE_DIRECTORY = os.path.join(tempfile.gettempdir(), "elex-cache")
 
-API_KEY = os.environ.get('AP_API_KEY', None)
-API_VERSION = os.environ.get('AP_API_VERSION', 'v2')
-BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(API_VERSION))
-CACHE_DIRECTORY = os.environ.get('ELEX_CACHE_DIRECTORY', _DEFAULT_CACHE_DIRECTORY)
+API_KEY = os.environ.get("AP_API_KEY", None)
+
+API_VERSION = os.environ.get("AP_API_VERSION", "v3")
+BASE_URL = os.environ.get(
+    "AP_API_BASE_URL", "https://api.ap.org/{0}".format(API_VERSION)
+)
+CACHE_DIRECTORY = os.environ.get("ELEX_CACHE_DIRECTORY", _DEFAULT_CACHE_DIRECTORY)
 
 session = requests.session()
-session.headers.update({'Accept-Encoding': 'gzip'})
-cache = CacheControl(session,
-                     cache=FileCache(CACHE_DIRECTORY),
-                     heuristic=EtagOnlyCache())
+
+# starting from v3 api key is passed in the header.
+session.headers.update({"Accept-Encoding": "gzip", "x-api-key": API_KEY})
+
+cache = CacheControl(
+    session, cache=FileCache(CACHE_DIRECTORY), heuristic=EtagOnlyCache()
+)

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -76,23 +76,23 @@ def api_request(path, **params):
 
     A properly formatted request:
     * Modifies the BASE_URL with a path.
-    * Contains an API_KEY.
     * Returns a response object.
 
     :param \**params:
         Extra parameters to pass to `requests`. For example,
-        `apiKey="<YOUR API KEY>`, your AP API key, or `national=True`,
-        for national-only results.
+        `national=True`, for national-only results.
     """
-    params['apiKey'] = params.get('apiKey') or elex.API_KEY
-    if not params['apiKey']:
-        raise APAPIKeyException()
+    params["format"] = "json"
 
-    params['format'] = 'json'
+    # from v3, apiKey is passed in the header, so let's remove it from the params
+    if "apiKey" in params:
+        del params["apiKey"]
 
     params = sorted(params.items())  # Sort for consistent caching
 
-    url = '{0}{1}'.format(elex.BASE_URL, path.replace('//', '/'))
+    url = "{0}{1}".format(elex.BASE_URL, path.replace("//", "/"))
+    print("Requesting {0} from {1}".format(params, url), file=sys.stderr)
+
     response = cache.get(url, params=params)
     response.raise_for_status()
 


### PR DESCRIPTION
Use new API key header and API version for calls to AP Elections API before 1/9/24

## Ticket #7118 


## Issue
v2 is deprecated, need to upgrade to v3 and change authentication by putting api key into request header.
